### PR TITLE
Add paper background to generated newsletter

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ This project contains a simple web page for generating a daily newsletter image.
 1. Open `index.html` in your web browser.
 2. Enter a title and article content.
 3. Click **Generate Newsletter** to download a PNG image of your newsletter.
+   The exported image uses `paper.png` as the paper-style background.
 
 No server or extra dependencies are required since everything runs in your browser.

--- a/index.html
+++ b/index.html
@@ -80,26 +80,30 @@
         canvas.height = height;
         const ctx = canvas.getContext('2d');
 
-        ctx.fillStyle = '#ffffff';
-        ctx.fillRect(0, 0, width, height);
+        // Load the background image
+        const bg = new Image();
+        bg.onload = function() {
+            ctx.drawImage(bg, 0, 0, width, height);
 
-        ctx.fillStyle = '#000000';
-        ctx.font = 'bold 32px sans-serif';
-        ctx.fillText(title, 20, 50);
+            ctx.fillStyle = '#000000';
+            ctx.font = 'bold 32px sans-serif';
+            ctx.fillText(title, 20, 50);
 
-        ctx.font = '16px sans-serif';
-        const lines = wrapText(ctx, content, width - 40);
-        let y = 90;
-        const lineHeight = 22;
-        lines.forEach(line => {
-            ctx.fillText(line, 20, y);
-            y += lineHeight;
-        });
+            ctx.font = '16px sans-serif';
+            const lines = wrapText(ctx, content, width - 40);
+            let y = 90;
+            const lineHeight = 22;
+            lines.forEach(line => {
+                ctx.fillText(line, 20, y);
+                y += lineHeight;
+            });
 
-        const link = document.createElement('a');
-        link.download = 'newsletter.png';
-        link.href = canvas.toDataURL('image/png');
-        link.click();
+            const link = document.createElement('a');
+            link.download = 'newsletter.png';
+            link.href = canvas.toDataURL('image/png');
+            link.click();
+        };
+        bg.src = 'paper.png';
     }
     </script>
 </body>


### PR DESCRIPTION
## Summary
- use `paper.png` as the background when generating the newsletter
- document that the generated image uses the paper background

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_683bfdcb3114832db11b2e332cb2409b