### PR TITLE
Fix newline splitting in wrapText

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
     </div>
     <script>
     function wrapText(ctx, text, maxWidth) {
-        const paragraphs = text.split(/\r?\n/);
+        const paragraphs = text.split(/\r\n|\n|\r/);
         const lines = [];
         paragraphs.forEach((paragraph, pIdx) => {
             const words = paragraph.split(' ');


### PR DESCRIPTION
## Summary
- handle CR and LF newline types when wrapping text

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683ca2d25d8c832da4dcc6316bac757b