### PR TITLE
Add right border to newsletter PNG

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,6 +211,12 @@
             ctx.lineTo(width * 0.9, y);
             ctx.stroke();
 
+            // Right border
+            ctx.beginPath();
+            ctx.moveTo(width - 1, 0);
+            ctx.lineTo(width - 1, height);
+            ctx.stroke();
+
             const link = document.createElement('a');
             link.download = 'newsletter.png';
             link.href = canvas.toDataURL('image/png');


### PR DESCRIPTION
## Summary
- add a vertical line on the canvas before exporting so the PNG has a right-side border

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ca2e76790832d89c1f10e424db80c