### PR TITLE
Add Kahua Kbuilder project skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ This project contains a simple web page for generating a daily newsletter image.
    The exported image now draws a built-in SVG paper texture for the background.
 
 No server or extra dependencies are required since everything runs in your browser.
+
+## Kbuilder Projects
+
+The `kbuilder` directory contains example XML files for Kahua's Kbuilder platform.
+These files demonstrate how to define forms and workflows for custom solutions.

--- a/kbuilder/README.md
+++ b/kbuilder/README.md
@@ -1,0 +1,7 @@
+# Kahua Kbuilder Projects
+
+This directory contains configuration files for Kahua's Kbuilder platform.
+The project files are written in XML to define forms, workflows, and other
+custom objects.
+
+Use these examples as a starting point for your own Kbuilder solutions.

--- a/kbuilder/example-project.xml
+++ b/kbuilder/example-project.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kbuilder-project name="SampleProject" version="1.0">
+    <description>Example project for Kahua Kbuilder.</description>
+    <form id="SampleForm">
+        <field name="Title" type="text" required="true"/>
+        <field name="Description" type="textarea"/>
+    </form>
+    <workflow id="SampleWorkflow">
+        <state id="start" name="Start"/>
+        <state id="review" name="Review"/>
+        <state id="complete" name="Complete"/>
+        <transition from="start" to="review"/>
+        <transition from="review" to="complete"/>
+    </workflow>
+</kbuilder-project>


### PR DESCRIPTION
## Summary
- add example XML project in new `kbuilder` folder
- document Kbuilder examples in the main README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852d3c5f27c832d9f18cea1efa166d6